### PR TITLE
added plan_updates, examples folder

### DIFF
--- a/CyberwatchApi.psm1
+++ b/CyberwatchApi.psm1
@@ -89,6 +89,11 @@ Class CbwApiClient {
         return $this.request('DELETE', "/api/v2/servers/${id}")
     }
 
+    [object] server_schedule_updates([string]$id, [Object]$content)
+    {
+        return $this.request('POST', "/api/v2/servers/${id}/updates", $content)
+    }
+
     [object] remote_accesses()
     {
         return $this.request('GET', '/api/v2/remote_accesses')

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ PS > $ram = $client.remote_accesses() | Select-Object -Last 1
 PS > $client.delete_remote_access($ram.id)
 ```
 
+- Use the client to schedule updates on a specific server (here 2 updates identified by its IDs):
+
+```powershell
+PS > $update_ids = @{91482, 94515)
+PS > $server_id = "c23673c6793f9fe5003a3e078cc5b1cc"
+
+# If start and end parameters are not specified, the server's deployment policy is used
+
+PS > $client.plan_updates($server_id, @{update_ids= $update_Ids; start="2019-09-14T03:00:00.000+02:00"; end="2019-09-14T09:00:00.000+02:00"})
+```
+
 ## Using the API with a self-signed certificate
 
 - Set up your client using the -trust_all_certificates parameter to allow requests to all certificates:

--- a/README.md
+++ b/README.md
@@ -173,3 +173,7 @@ PS > $client.plan_updates($server_id, @{update_ids= $update_Ids; start="2019-09-
 ```powershell
 PS> $client = Get-CyberwatchApi -api_url $API_URL -api_key $API_KEY -secret_key $SECRET_KEY -trust_all_certificates $true
 ```
+
+## More examples
+
+See more examples and use cases in the [examples directory](examples)

--- a/examples/plan_anomalies.psm1
+++ b/examples/plan_anomalies.psm1
@@ -1,0 +1,15 @@
+# Powershell script to retry every updates with an anomaly status on every computers at their deploying period
+
+$servers = $client.servers()
+
+foreach ($server in $servers) {
+    $serverFull = $client.server($server.id)
+    $serverUpdates = $serverFull.updates
+    $updateIds = @()
+    foreach ($update in $serverUpdates) {
+        If ($update.status.comment -eq "anomaly") {
+            $updateIds += $update.id
+        }
+    }
+    $client.server_schedule_updates($server.id, @{update_ids= @($updateIds)})
+}


### PR DESCRIPTION
- Added plan_updates route to be able to retry updates identified by its ID on a server

- Created Examples folder to store examples scripts

- Example of an update script that can find every updates with the status "anomaly" and plan them for the next maintenance schedule 

- Updated documentation.md with the new changes