### PR TITLE
fix route group by removing wrong parameters

### DIFF
--- a/CyberwatchApi.psm1
+++ b/CyberwatchApi.psm1
@@ -119,7 +119,7 @@ Class CbwApiClient {
         return $this.request('DELETE', "/api/v2/remote_accesses/${id}")
     }
 
-    [object] groups([string]$id)
+    [object] groups()
     {
         return $this.request('GET', "/api/v2/groups")
     }


### PR DESCRIPTION
The route "groups" do not need a $id parameter