### PR TITLE
Add -BasicUrlParsing param for compatibility

### DIFF
--- a/CyberwatchApi.psm1
+++ b/CyberwatchApi.psm1
@@ -53,7 +53,7 @@ Param    (
         "accept"        = "application/json";
         "Date"          = $timestamp
         "Authorization" = "Cyberwatch APIAuth-HMAC-SHA256 ${API_KEY}:$signature"
-    } -ContentType $content_type -Body $body_content
+    } -ContentType $content_type -Body $body_content -UseBasicParsing
 }
 
 Function SendApiRequestPagination


### PR DESCRIPTION
Adding the parameter allows for more compatibility by fixing the following error :

`Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch 
configuration is not complete. Specify the UseBasicParsing parameter and try again.`