### PR TITLE
Add Release to Powershell Gallery github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release Workflow
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Release to PowerShell Gallery
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Module to PowerShell Gallery
+        uses: pcgeek86/publish-powershell-module-action@v20
+        id: publish-module
+        with:
+          NuGetApiKey: ${{ secrets.PS_GALLERY_KEY }}


### PR DESCRIPTION
This adds a new job that releases the module and publishes it to PowerShell Gallery. After this is merged, the publication workflow will be to start the job manually: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow