### PR TITLE
Checkout repository before publishing action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ jobs:
     name: Release to PowerShell Gallery
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Publish Module to PowerShell Gallery
         uses: pcgeek86/publish-powershell-module-action@v20
         id: publish-module


### PR DESCRIPTION
This ensures the project is checked out before it is published.