### PR TITLE
send charset in content_type header

### DIFF
--- a/CyberwatchApi/CyberwatchApi.psm1
+++ b/CyberwatchApi/CyberwatchApi.psm1
@@ -25,7 +25,7 @@ Param    (
     $uri = "${API_URL}${request_URI}"
 
     if ($content) {
-        $content_type = 'application/json'
+        $content_type = 'application/json ; charset=utf-8'
         $body_content = $content | ConvertTo-Json
     }
     elseif ($query_params) {


### PR DESCRIPTION
Modified : charset=utf-8  has been added to the $content_type variable to avoid problem when sending asset configuration file with unexpected character using air gap