### PR TITLE
Modified : Link to the client method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## New API method
 
-This module has been deprecated. Please consider using [the PowerShell Invoke-WebRequest cmdlet](https://docs.cyberwatch.fr/en/9_API_documentation/powerShell_snippets.html).
+This module has been deprecated. Please consider using [the PowerShell Invoke-WebRequest cmdlet](https://docs.cyberwatch.fr/en/API_documentation/powerShell_snippets.html).
 
 Please contact Cyberwatch support if you need help to migrate your existing scripts to the new client.
 


### PR DESCRIPTION
Here, the number in the URL to the new API client method has been removed to correspond to the new URL.